### PR TITLE
Removing what appears to be an extraneous '+' operator.

### DIFF
--- a/src/reduce.js
+++ b/src/reduce.js
@@ -8,7 +8,7 @@ function crossfilter_reduceDecrement(p) {
 
 function crossfilter_reduceAdd(f) {
   return function(p, v) {
-    return p + +f(v);
+    return p + f(v);
   };
 }
 


### PR DESCRIPTION
I noticed there are two +'s in crossfilter_reduceAdd function in src/reduce.js function. Is this intended? If so, I would like to know the reason behind it (maybe some JS quirks).
