### PR TITLE
Undeclared variables.

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -377,7 +377,8 @@ function crossfilter() {
 
         var i,
             k,
-            n;
+            n,
+            g;
 
         // Add the added values.
         for (i = 0, n = added.length; i < n; ++i) {

--- a/src/quicksort.js
+++ b/src/quicksort.js
@@ -30,6 +30,8 @@ function quicksort_by(f) {
         e4 = a[i4], x4 = f(e4),
         e5 = a[i5], x5 = f(e5);
 
+    var t;
+
     // Sort the selected 5 elements using a sorting network.
     if (x1 > x2) t = e1, e1 = e2, e2 = t, t = x1, x1 = x2, x2 = t;
     if (x4 > x5) t = e4, e4 = e5, e5 = t, t = x4, x4 = x5, x5 = t;


### PR DESCRIPTION
Stumbled across an undeclared variable `t` in `quicksort.js` in actual use. It depends on the relative order of the quicksort pivot values - in particular, ordered values won't hit it (repro via node):

``` javascript
var crossfilter = require('crossfilter');
var assert = require('assert');

var testdata = [];
for (var i=0; i<32; i++) { testdata[i] = { f : (i % 2 ? "foo" : "bar") } }
var cf = crossfilter(testdata);

var t = "TEE";
var dim = cf.dimension(function(d) { return d.f });
assert.equal(t, "TEE");
```

Linting (with [davepacheco/javascriptlint](https://github.com/davepacheco/javascriptlint)) to track this down also found a suspicously-absent declaration of `g` in `updateMany()`, not reproduced.
