### PR TITLE
fix error in recomputing filters

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -296,7 +296,7 @@ function crossfilter() {
           removed = [];
 
       for (i = 0; i < n; ++i) {
-        if (!(filters[k = index[i]] & one) ^ (x = f(values[i], k))) {
+        if (!(filters[k = index[i]] & one) ^ (x = f(values[i], i))) {
           if (x) filters[k] &= zero, added.push(k);
           else filters[k] |= one, removed.push(k);
         }


### PR DESCRIPTION
when switching from a function filter to a bounds based filter
(exact or range), bounds were being compared using the wrong
index, leading to incorrect results.

fixes issue #93
