### PR TITLE
Added cross() operation to group object

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "crossfilter",
   "repo": "square/crossfilter",
   "description": "Fast n-dimensional filtering and grouping of records.",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "keywords": [],
   "main": "crossfilter.js",
   "scripts": [

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "crossfilter",
   "repo": "square/crossfilter",
   "description": "Fast n-dimensional filtering and grouping of records.",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "keywords": [],
   "main": "crossfilter.js",
   "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crossfilter",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Fast multidimensional filtering for coordinated views.",
   "keywords": [
     "square",

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -534,6 +534,62 @@ suite.addBatch({
           return data;
         },
 
+        "cross": {
+          topic: function(data) {
+            data.cross = data.type.types.cross(data.date.hours);
+            data.type.filterExact(data.honorCrossFilter = 'visa');
+            data.honorCross = data.type.types.cross(data.date.hours, true);
+            data.type.filterAll();
+            return data;
+          },
+
+          "cross size is right": function(data) {
+            var l = data.cross.length;
+            //data.cross.forEach(function(cross) { l += cross.length; });
+            assert.equal(l, data.date.hours.size() * data.type.types.size());
+            //console.log("Cross:", data.cross);
+          },
+
+          "crossing is same as filtering one-by-one" : function(data) {
+            data.type.types.all().forEach(function(type, t) {
+              data.type.filterExact(type.key);
+              //var i, crossed = data.cross[t], grouped = data.date.hours.all();
+              var i, crossed = data.cross.filter(function(g) { return g.key == type.key; }),
+                  grouped = data.date.hours.all();
+              assert.equal(crossed.length, grouped.length);
+              for (i = 0; i < crossed.length; i++) {
+                assert.equal(crossed[i].cross, grouped[i].key);
+                assert.equal(crossed[i].value, grouped[i].value);
+              }
+            });
+            data.type.filterAll();
+          },
+
+          "crossing while honoring is same as filtering the other one-by-one" : function(data) {
+            data.type.filterExact(data.honorCrossFilter);
+            var grouped = data.date.hours.all();
+            data.type.types.all().forEach(function(type, t) {
+              var i, crossed = data.honorCross.filter(function(g) { return g.key == type.key; });
+              if (type.key === data.honorCrossFilter) {
+                assert.equal(crossed.length, grouped.length);
+                for (i = 0; i < crossed.length; i++) {
+                  assert.equal(crossed[i].cross, grouped[i].key);
+                  assert.equal(crossed[i].value, grouped[i].value); //, "Failed on cross: " + crossed[i].key + " x " + crossed[i].cross);
+                }
+              }
+              else {
+                assert.equal(crossed.length, grouped.length);
+                for (i = 0; i < crossed.length; i++) {
+                  assert.equal(crossed[i].cross, grouped[i].key);
+                  assert.equal(crossed[i].value, 0); //, "Failed on cross: " + crossed[i].key + " x " + crossed[i].cross);
+                }
+              }
+            });
+            data.type.filterAll();
+          }
+
+        },
+
         "key defaults to value": function(data) {
           assert.deepEqual(data.type.types.top(Infinity), [
             {key: "tab", value: 32},


### PR DESCRIPTION
Added a new cross() method to the group object to make it easier to get 2-dimensional data out of crossfilter.  The current implementation scans the whole data set and doesn't use the incremental update capabilities, but it does use the group indices.

Basically, if group A has keys "a", "b", and "c" and group X has keys "x", "y", and "z", then calling A.cross(X) will give you an array with 9 values, one for each combination.  Should be faster than looping over one group, calling filter on the dimension for each group key (assuming identity group transform), and then reducing using the other group.

There is an option to honor or ignore the filters on the two crossed dimensions – filters on other dimensions will always be honored.

Also added a couple of tests but I won't pretend the coverage is 100%.