### PR TITLE
Add a convenience function for specifying reducing by single object

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -348,6 +348,7 @@ function crossfilter() {
         reduce: reduce,
         reduceCount: reduceCount,
         reduceSum: reduceSum,
+        reduceObj: reduceObj,
         order: order,
         orderNatural: orderNatural,
         size: size,
@@ -656,6 +657,11 @@ function crossfilter() {
       // A convenience method for reducing by sum(value).
       function reduceSum(value) {
         return reduce(crossfilter_reduceAdd(value), crossfilter_reduceSubtract(value), crossfilter_zero);
+      }
+
+      // A convenience method for supplying reduce behaviour as a single object.
+      function reduceObj(obj) {
+        return reduce(obj.add, obj.remove, obj.initial);
       }
 
       // Sets the reduce order, using the specified accessor.


### PR DESCRIPTION
This change makes it more convenient to create "reducer" objects encapsulating particular
reducing strategy.
