### PR TITLE
Allows reduce() to accept object containing three functions

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -647,9 +647,9 @@ function crossfilter() {
       // Sets the reduce behavior for this group to use the specified functions.
       // This method lazily recomputes the reduce values, waiting until needed.
       function reduce(add, remove, initial) {
-        reduceAdd = add;
-        reduceRemove = remove;
-        reduceInitial = initial;
+        reduceAdd = add.add ? add.add : add;
+        reduceRemove = add.remove ? add.remove : remove;
+        reduceInitial = add.init ? add.init : initial;
         resetNeeded = true;
         return group;
       }


### PR DESCRIPTION
This is a bit hacky but here is the intent. If reduce() could accept not only three functions but also an object containing three functions, it would be easier to build custom aggregations for crossfilter.

For example, a function:

``` javascript
weightedMean(freq, weight)
```

with "freq" being frequencies accessor function and "weight" being weights accessor function, would return something along the lines of:

``` javascript
{
    add : weightedMeanAdd,
    remove : weightedMeanRemove,
    initial : weightedMeanInitial
}
```

All fields of this object would be functions, similar to

``` javascript
crossfilter_reduceAdd(value), crossfilter_reduceSubtract(value), crossfilter_zero
```
