### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "crossfilter",
+  "main": "crossfilter.js",
+  "version": "1.3.11",
+  "homepage": "https://github.com/square/crossfilter",
+  "authors": [
+    "Mike Bostock (http://bost.ocks.org/mike)"
+  ],
+  "description": "Fast n-dimensional filtering and grouping of records.",
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "license": "Apache",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "test"
+  ]
+}


### PR DESCRIPTION
I understand this is not a priority but I was trying to add a bower webjar (http://www.webjars.org/bower) and wasn't able to do it, even though crossfilter is registered in Bower. I guess it is because of the absence of a `bower.json`.

Feel free to close right away if not interested.