### PR TITLE
Add status and links to current crossfilter organization to gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,15 @@ aside {
 
 <h2>Fast Multidimensional Filtering for Coordinated Views</h2>
 
+<h3  style="color:red">Status</h3>
+
+<p style="color:red">
+Crossfilter is not under active development, maintenance or support by Square, its original author Mike Bostock, or the recent contributors (Jason Davies, Tom Carden). We still welcome genuine bug-fixes and PRs but consider the current API and feature-set (~1.3.12) essentially complete.
+
+A new <a href="https://github.com/crossfilter" title="Crossfilter on Github">Crossfilter Organization</a> has been created on Github and is home to an <a href="https://github.com/crossfilter/crossfilter">actively maintained fork of Crossfilter</a>. This version is already used by popular library <a href="https://dc-js.github.io/dc.js/">DC.js</a> and the contributors are working on improved APIs and performance improvements for current Javascript VMs. There are no plans to merge or publish new versions under the original Square repository or npm package.
+</p>
+
+
 <p><b>Crossfilter</b> is a <a href="https://github.com/square/crossfilter">JavaScript library</a> for exploring large multivariate datasets in the browser. Crossfilter supports extremely fast (&lt;30ms) interaction with coordinated views, even with datasets containing a million or more records; we built it to power analytics for <a href="https://squareup.com/register">Square Register</a>, allowing merchants to slice and dice their payment history fluidly.
 
 <p>Since most interactions only involve a single dimension, and then only small adjustments are made to the filter values, incremental filtering and reducing is significantly faster than starting from scratch. Crossfilter uses sorted indexes (and a few bit-twiddling hacks) to make this possible, dramatically increasing the perfor&shy;mance of live histograms and top-<i>K</i> lists. For more details on how Crossfilter works, see the <a href="https://github.com/square/crossfilter/wiki/API-Reference">API reference</a>.


### PR DESCRIPTION
Copies the status blurb from the repo page to the gh-pages page to help people who only see that. 